### PR TITLE
add  prior to renderer commmand execulate

### DIFF
--- a/utils/up.js
+++ b/utils/up.js
@@ -9,8 +9,8 @@ module.exports = () => {
     process.exit(1);
   }
   try {
-    cp.execSync('tuture-renderer');
     signale.success('Tuture renderer is served on http://localhost:3000.');
+    cp.execSync('tuture-renderer');
   } catch (e) {
     signale.error('tuture-renderer is not available!');
   }


### PR DESCRIPTION
@mRcfps I found that `signale.success()` prior to `tuture-renderer` command, can output `success`  hint. If not, `tuture-renderer` is a sustainable command, and it will not execulate `signale.success()`.

![image](https://user-images.githubusercontent.com/26423749/40765214-54c67628-64de-11e8-9594-7f4889fa429d.png)
