### PR TITLE
Full scale test upgrade

### DIFF
--- a/tests/destroy.test.js
+++ b/tests/destroy.test.js
@@ -8,7 +8,7 @@ let tmpDirs = Array();
 describe('tuture destroy', () => {
 
   afterAll(() => {
-    tmpDirs.map(dir => fs.removeSync(dir));
+    tmpDirs.forEach(dir => fs.removeSync(dir));
     process.chdir(path.join(__dirname, '..'));
   });
 

--- a/tests/destroy.test.js
+++ b/tests/destroy.test.js
@@ -12,53 +12,31 @@ describe('tuture destroy', () => {
     process.chdir(path.join(__dirname, '..'));
   });
 
-  describe('(no args)', () => {
+  describe('normal destroy', () => {
     const tuturePath = utils.createTutureSuite();
     tmpDirs.push(tuturePath);
     process.chdir(tuturePath);
-    const cp = utils.run(['destroy']);
+    const cp2 = utils.run(['destroy', '-f']);
 
-    it('should prompt message', () => {
-      expect(cp.stdout.toString()).toMatch(/Are you sure?/);
+    it('should exit with status 0', () => {
+      expect(cp2.status).toBe(0);
     });
 
-    // TODO: Untangle this prompt mess.
-    it.skip('should not delete tuture files when choosing default', () => {
-      expect(fs.existsSync(path.join('.tuture', 'diff'))).toBe(true);
-      expect(fs.existsSync('tuture.yml')).toBe(true);
+    it('should delete all tuture files', () => {
+      process.chdir(tuturePath);
+      expect(fs.existsSync(path.join('.tuture', 'diff'))).toBe(false);
+      expect(fs.existsSync('tuture.yml')).toBe(false);
     });
   });
 
-  describe('-f', () => {
-    testDestroy(['destroy', '-f']);
-  });
+  describe('no tuture files present', () => {
+    const nonTuturePath = utils.createEmptyDir();
+    tmpDirs.push(nonTuturePath);
+    process.chdir(nonTuturePath);
+    const cp = utils.run(['destroy', '-f']);
 
-  describe('--force', () => {
-    testDestroy(['destroy', '--force']);
+    it('should refuse to destroy', () => {
+      expect(cp.status).toBe(1);
+    });
   });
 });
-
-function testDestroy(args) {
-  const nonTuturePath = utils.createEmptyDir();
-  tmpDirs.push(nonTuturePath);
-  process.chdir(nonTuturePath);
-  const cp1 = utils.run(args);
-
-  it('should refuse to destroy when no tuture files present', () => {
-    expect(cp1.status).toBe(1);
-  });
-
-  const tuturePath = utils.createTutureSuite();
-  tmpDirs.push(tuturePath);
-  process.chdir(tuturePath);
-  const cp2 = utils.run(args);
-
-  it('should exit with status 0', () => {
-    expect(cp2.status).toBe(0);
-  });
-
-  it('should delete all tuture files', () => {
-    expect(fs.existsSync(path.join('.tuture', 'diff'))).toBe(false);
-    expect(fs.existsSync('tuture.yml')).toBe(false);
-  });
-}

--- a/tests/destroy.test.js
+++ b/tests/destroy.test.js
@@ -16,10 +16,10 @@ describe('tuture destroy', () => {
     const tuturePath = utils.createTutureSuite();
     tmpDirs.push(tuturePath);
     process.chdir(tuturePath);
-    const cp2 = utils.run(['destroy', '-f']);
+    const cp = utils.run(['destroy', '-f']);
 
     it('should exit with status 0', () => {
-      expect(cp2.status).toBe(0);
+      expect(cp.status).toBe(0);
     });
 
     it('should delete all tuture files', () => {

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -15,51 +15,65 @@ describe('tuture init', () => {
     process.chdir(path.join(__dirname, '..'));
   });
 
-  describe('no .gitignore', () => {
-    // NOTE: When contriving testRepo, put `files` in alphabetic order.
-    const testRepo = [
-      {
-        message: 'Commit 1',
-        files: ['test1.js', 'test2.js'],
-      },
-      {
-        message: 'Commit 2',
-        files: ['package-lock.json'],
-      },
-    ];
-    testInit(testRepo);
-  });
+  describe('inside a Git repo', () => {
 
-  describe('.gitignore without ignoring .tuture', () => {
-    const testRepo = [
-      {
-        message: 'Test',
-        files: ['.gitignore', 'app.js'],
-      },
-      {
-        message: 'Another Test',
-        files: ['dir/test1.js', 'dir/yarn.lock'],
-      },
-      {
-        message: 'Still Another Test',
-        files: ['dir/test2.js'],
-      },
-    ];
-    testInit(testRepo);
-  });
+    describe('no .gitignore', () => {
+      // NOTE: When contriving testRepo, put `files` in alphabetic order.
+      const testRepo = [
+        {
+          message: 'Commit 1',
+          files: ['test1.js', 'test2.js'],
+        },
+        {
+          message: 'Commit 2',
+          files: ['package-lock.json'],
+        },
+      ];
+      testInit(testRepo);
+    });
 
-  describe('.gitignore already having .tuture ignored', () => {
-    const testRepo = [
-      {
-        message: 'First Commit',
-        files: ['.gitignore', 'test1.js'],
-      },
-      {
-        message: 'Second Commit',
-        files: ['test2.js'],
-      },
-    ];
-    testInit(testRepo, true);
+    describe('.gitignore without ignoring .tuture', () => {
+      const testRepo = [
+        {
+          message: 'Test',
+          files: ['.gitignore', 'app.js'],
+        },
+        {
+          message: 'Another Test',
+          files: ['dir/test1.js', 'dir/yarn.lock'],
+        },
+        {
+          message: 'Still Another Test',
+          files: ['dir/test2.js'],
+        },
+      ];
+      testInit(testRepo);
+    });
+
+    describe('.gitignore already having .tuture ignored', () => {
+      const testRepo = [
+        {
+          message: 'First Commit',
+          files: ['.gitignore', 'test1.js'],
+        },
+        {
+          message: 'Second Commit',
+          files: ['test2.js'],
+        },
+      ];
+      testInit(testRepo, true);
+    });
+
+    describe('no commit at all', () => {
+      const gitRepo = utils.createGitRepo([]);
+      tmpDirs.push(gitRepo);
+
+      it('should refuse to init', () => {
+        process.chdir(gitRepo);
+        const cp = utils.run(['init', '-y']);
+        expect(cp.status).toBe(1);
+      });
+    });
   });
 
   describe('outside a git repo', () => {
@@ -68,17 +82,6 @@ describe('tuture init', () => {
 
     it('should refuse to init', () => {
       process.chdir(nonGitRepo);
-      const cp = utils.run(['init', '-y']);
-      expect(cp.status).toBe(1);
-    });
-  });
-
-  describe('inside a git repo with no commit', () => {
-    const gitRepo = utils.createGitRepo([]);
-    tmpDirs.push(gitRepo);
-
-    it('should refuse to init', () => {
-      process.chdir(gitRepo);
       const cp = utils.run(['init', '-y']);
       expect(cp.status).toBe(1);
     });

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -15,6 +15,17 @@ describe('tuture init', () => {
     process.chdir(path.join(__dirname, '..'));
   });
 
+  describe('outside a git repo', () => {
+    const nonGitRepo = utils.createEmptyDir();
+    tmpDirs.push(nonGitRepo);
+
+    it('should refuse to init', () => {
+      process.chdir(nonGitRepo);
+      const cp = utils.run(['init', '-y']);
+      expect(cp.status).toBe(1);
+    });
+  });
+
   describe('inside a Git repo', () => {
 
     describe('no .gitignore', () => {
@@ -73,17 +84,6 @@ describe('tuture init', () => {
         const cp = utils.run(['init', '-y']);
         expect(cp.status).toBe(1);
       });
-    });
-  });
-
-  describe('outside a git repo', () => {
-    const nonGitRepo = utils.createEmptyDir();
-    tmpDirs.push(nonGitRepo);
-
-    it('should refuse to init', () => {
-      process.chdir(nonGitRepo);
-      const cp = utils.run(['init', '-y']);
-      expect(cp.status).toBe(1);
     });
   });
 });

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -11,7 +11,7 @@ let tmpDirs = Array();
 describe('tuture init', () => {
 
   afterAll(() => {
-    tmpDirs.map(dir => fs.removeSync(dir));
+    tmpDirs.forEach(dir => fs.removeSync(dir));
     process.chdir(path.join(__dirname, '..'));
   });
 

--- a/tests/tuture.test.js
+++ b/tests/tuture.test.js
@@ -35,7 +35,7 @@ describe('tuture', () => {
     });
   });
 
-  describe('unknown args', () => {
+  describe('(unknown args)', () => {
     it('should exit(1) when unknown commands are given', () => {
       expect(run(['foobar']).status).toBe(1);
     });

--- a/tests/up.test.js
+++ b/tests/up.test.js
@@ -8,7 +8,7 @@ let tmpDirs = Array();
 describe('tuture up', () => {
 
   afterAll(() => {
-    tmpDirs.map(dir => fs.removeSync(dir));
+    tmpDirs.forEach(dir => fs.removeSync(dir));
     process.chdir(path.join(__dirname, '..'));
   });
 

--- a/tests/up.test.js
+++ b/tests/up.test.js
@@ -12,23 +12,14 @@ describe('tuture up', () => {
     process.chdir(path.join(__dirname, '..'));
   });
 
-  describe('(no args)', () => {
+  describe('tuture is not initialized', () => {
     const nonTuturePath = utils.createEmptyDir();
     tmpDirs.push(nonTuturePath);
-    process.chdir(nonTuturePath);
-    const cp1 = utils.run(['up']);
 
-    it('should refuse to up when tuture is not initialized', () => {
-      expect(cp1.status).toBe(1);
-    });
-
-    // TODO: Figure out how to test whether tuture-renderer is invoked.
-    it.skip('should exit with status 0 when everything is ok', () => {
-      const tuturePath = utils.createTutureSuite();
-      tmpDirs.push(tuturePath);
-      process.chdir(tuturePath);
-      const cp2 = utils.run(['up']);
-      expect(cp2.status).toBe(0);
+    it('should refuse to up', () => {
+      process.chdir(nonTuturePath);
+      const cp = utils.run(['up']);
+      expect(cp.status).toBe(1);
     });
   });
 });

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,20 +1,31 @@
+const cp = require('child_process');
 const fs = require('fs-extra');
+const minimatch = require('minimatch');
+const path = require('path');
+const signale = require('signale');
 
 exports.EXPLAIN_PLACEHOLDER = '<YOUR EXPLANATION HERE>';
 exports.TUTURE_ROOT = '.tuture';
 
 // Filename patterns that shoule be collapsed in renderer.
-exports.collapsedFiles = [
+const collapsedFiles = [
   '.gitignore',
   'package-lock.json',
   'yarn.lock',
 ];
 
 /**
+ * Return whether a file should be collapsed.
+ * @param {String} fileName Name of file to check
+ */
+exports.shouldBeCollapsed = fileName =>
+  collapsedFiles.some(pattern => minimatch(path.basename(fileName), pattern));
+
+/**
  * Check if .tuture directory and tuture.yml both exists.
  */
-exports.ifTutureSuiteExists =
-  () => fs.existsSync(this.TUTURE_ROOT) && fs.existsSync('tuture.yml');
+exports.ifTutureSuiteExists = () =>
+  fs.existsSync(this.TUTURE_ROOT) && fs.existsSync('tuture.yml');
 
 /**
  * Remove all Tuture-related files.
@@ -22,4 +33,15 @@ exports.ifTutureSuiteExists =
 exports.removeTutureSuite = async () => {
   await fs.remove('tuture.yml');
   await fs.remove(this.TUTURE_ROOT);
+};
+
+/**
+ * Check cwd is a valid Git repo with at least one commit.
+ */
+exports.checkGitEnv = () => {
+  const subprocess = cp.spawnSync('git', ['log']);
+  if (subprocess.status) {
+    signale.fatal(subprocess.stderr.toString().replace('fatal:', ''));
+    process.exit(1);
+  }
 };

--- a/utils/git.js
+++ b/utils/git.js
@@ -1,7 +1,6 @@
 const cp = require('child_process');
 
 const fs = require('fs-extra');
-const minimatch = require('minimatch');
 const path = require('path');
 const signale = require('signale');
 
@@ -44,7 +43,7 @@ function getGitDiff(commit) {
     .filter(file => file !== 'tuture.yml')
     .map((file) => {
       const diffFile = { file, explain: common.EXPLAIN_PLACEHOLDER };
-      if (common.collapsedFiles.some(pattern => minimatch(path.basename(file), pattern))) {
+      if (common.shouldBeCollapsed(file)) {
         diffFile.collapse = true;
       }
       return diffFile;

--- a/utils/init.js
+++ b/utils/init.js
@@ -104,6 +104,8 @@ function appendGitignore() {
 }
 
 module.exports = async (options) => {
+  common.checkGitEnv();
+
   const tuture = await promptMetaData(!options.yes);
   fs.mkdirpSync(path.join(common.TUTURE_ROOT, 'diff'));
 

--- a/utils/up.js
+++ b/utils/up.js
@@ -14,5 +14,6 @@ module.exports = () => {
     cp.execSync('tuture-renderer');
   } catch (e) {
     signale.error('tuture-renderer is not available!');
+    process.exit(1);
   }
 };


### PR DESCRIPTION
## Changes of CLI

- In **utils/common.js**, expose `shouldBeCollapsed` rather than `collapsedFiles`
- Add `checkGitEnv` at the very beginning of up command

## Changes of tests

- Remove duplicate tests of shorthand (like `-f` and `--force`), because that's the job of commander
- Enable customization of `testRepo` for better test coverage of init command
- Use for-loop to thoroughly test `tuture` object
- Abandon testing prompts (in test environment there is no TTY which is required by prompting)
- Add tests for **.gitignore** file