### PR TITLE
Use simple git again for async style of extracting git diffs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "minimatch": "^3.0.4",
     "ora": "^2.1.0",
     "prompts": "^0.1.8",
-    "signale": "^1.1.0"
+    "signale": "^1.1.0",
+    "simple-git": "^1.95.1"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,8 +1,6 @@
-const cp = require('child_process');
 const fs = require('fs-extra');
 const minimatch = require('minimatch');
 const path = require('path');
-const signale = require('signale');
 
 exports.EXPLAIN_PLACEHOLDER = '<YOUR EXPLANATION HERE>';
 exports.TUTURE_ROOT = '.tuture';
@@ -33,15 +31,4 @@ exports.ifTutureSuiteExists = () =>
 exports.removeTutureSuite = async () => {
   await fs.remove('tuture.yml');
   await fs.remove(this.TUTURE_ROOT);
-};
-
-/**
- * Check cwd is a valid Git repo with at least one commit.
- */
-exports.checkGitEnv = () => {
-  const subprocess = cp.spawnSync('git', ['log']);
-  if (subprocess.status) {
-    signale.fatal(subprocess.stderr.toString().replace('fatal:', ''));
-    process.exit(1);
-  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3242,6 +3242,12 @@ signale@^1.1.0:
     figures "^2.0.0"
     pkg-conf "^2.1.0"
 
+simple-git@^1.95.1:
+  version "1.95.1"
+  resolved "http://registry.npm.taobao.org/simple-git/download/simple-git-1.95.1.tgz#8f23b998f0d9e877b12e0291200ce115e004878c"
+  dependencies:
+    debug "^3.1.0"
+
 sisteransi@^0.1.0:
   version "0.1.0"
   resolved "http://registry.npm.taobao.org/sisteransi/download/sisteransi-0.1.0.tgz#2e6706ac427019b84e60f751d588d87920484f25"


### PR DESCRIPTION
Previously I removed simple-git for lighter dependencies and synchronized code, but the spinner stops working. So here is the remedy.

PS: simple-git is actually an extremely lightweight package (depends on **debug** only, see [here](https://www.npmjs.com/package/simple-git)).