### PR TITLE
cli: Error handling refactoring and bug fix about ignoring certain commits

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const minimatch = require('minimatch');
 const path = require('path');
+const signale = require('signale');
 
 exports.EXPLAIN_PLACEHOLDER = '<YOUR EXPLANATION HERE>';
 exports.TUTURE_ROOT = '.tuture';
@@ -31,4 +32,13 @@ exports.ifTutureSuiteExists = () =>
 exports.removeTutureSuite = async () => {
   await fs.remove('tuture.yml');
   await fs.remove(this.TUTURE_ROOT);
+};
+
+/**
+ * Output error message and exit with status 1.
+ * @param {String} message Error message
+ */
+exports.errAndExit = (message) => {
+  signale.fatal(message.trim().replace('fatal: ', ''));
+  process.exit(1);
 };

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,7 +1,6 @@
 const fs = require('fs-extra');
 const git = require('simple-git/promise')('.');
 const path = require('path');
-const signale = require('signale');
 
 const common = require('./common');
 
@@ -11,9 +10,8 @@ const common = require('./common');
 async function checkGitEnv() {
   try {
     await git.log();
-  } catch (e) {
-    signale.error(e);
-    process.exit(1);
+  } catch (err) {
+    common.errAndExit(err.message);
   }
 }
 
@@ -27,9 +25,8 @@ async function runGitCommand(args) {
   let res = null;
   try {
     res = await git.raw(args);
-  } catch (e) {
-    signale.error(e);
-    process.exit(1);
+  } catch (err) {
+    common.errAndExit(err.message);
   }
   return res;
 }

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,5 +1,5 @@
 const fs = require('fs-extra');
-const git = require('simple-git/promise')('.');
+const git = require('simple-git/promise')('.').silent(true);
 const path = require('path');
 
 const common = require('./common');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -61,10 +61,7 @@ async function promptMetaData(shouldPrompt) {
     },
   ];
 
-  const onCancel = () => {
-    signale.fatal('Aborted!');
-    process.exit(1);
-  };
+  const onCancel = () => common.errAndExit('Aborted!');
 
   return shouldPrompt ? prompts(questions, { onCancel }) : defaultValues;
 }
@@ -136,12 +133,9 @@ async function initTuture(options) {
 
     appendGitignore();
     git.appendGitHook();
-  } catch (e) {
-    signale.error(e.message);
-    const spinner = ora('Cleaning...').start();
+  } catch (err) {
     await common.removeTutureSuite();
-    spinner.stop();
-    process.exit(1);
+    common.errAndExit(err.message);
   }
 }
 
@@ -150,16 +144,14 @@ async function initTuture(options) {
  */
 async function reloadTuture() {
   if (!common.ifTutureSuiteExists()) {
-    signale.error('Tuture has not been initialized!');
-    process.exit(1);
+    common.errAndExit('Tuture has not been initialized!');
   }
 
   let tuture = null;
   try {
     tuture = yaml.safeLoad(fs.readFileSync('tuture.yml'), 'utf8');
-  } catch (e) {
-    signale.error(e);
-    process.exit(1);
+  } catch (err) {
+    common.errAndExit(err.message);
   }
 
   const currentSteps = await getSteps();
@@ -181,15 +173,13 @@ async function reloadTuture() {
  */
 function startRenderer() {
   if (!common.ifTutureSuiteExists()) {
-    signale.error('Tuture has not been initialized!');
-    process.exit(1);
+    common.errAndExit('Tuture has not been initialized!');
   }
   try {
     signale.success('Tuture renderer is served on http://localhost:3000.');
     cp.execSync('tuture-renderer');
   } catch (e) {
-    signale.error('tuture-renderer is not available!');
-    process.exit(1);
+    common.errAndExit('tuture-renderer is not available!');
   }
 }
 
@@ -199,14 +189,10 @@ function startRenderer() {
  */
 async function destroyTuture(options) {
   if (!common.ifTutureSuiteExists()) {
-    signale.error('No Tuture tutorial to destroy!');
-    process.exit(1);
+    common.errAndExit('No Tuture tutorial to destroy!');
   }
 
-  const onCancel = () => {
-    signale.fatal('Aborted!');
-    process.exit(1);
-  };
+  const onCancel = () => common.errAndExit('Aborted!');
 
   const answer = options.force ? true : await prompts({
     type: 'confirm',
@@ -215,8 +201,7 @@ async function destroyTuture(options) {
     initial: false,
   }, { onCancel });
   if (!answer) {
-    console.log('Aborted!');
-    process.exit(1);
+    common.errAndExit('Aborted!');
   }
 
   git.removeGitHook();
@@ -233,6 +218,5 @@ exports.startRenderer = startRenderer;
 exports.destroyTuture = destroyTuture;
 
 exports.handleUnknownCmd = (cmd) => {
-  console.log(`Unknown command: ${cmd}`);
-  process.exit(1);
+  common.errAndExit(`Unknown command: ${cmd}`);
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,7 +71,7 @@ async function makeSteps() {
   return logs
     .reverse()
     // filter out commits whose commit message starts with 'tuture:'
-    .filter(log => !log.startsWith('tuture:'))
+    .filter(log => !log.slice(8, log.length).startsWith('tuture:'))
     .map(async (log) => {
       const commit = log.slice(0, 7);
       const msg = log.slice(8, log.length);

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -65,6 +65,24 @@ describe('tuture init', () => {
       testInit(testRepo, true);
     });
 
+    describe('have commits with messages starting with "tuture:"', () => {
+      const testRepo = [
+        {
+          message: 'Do something',
+          files: ['bar.js', 'foo.js'],
+        },
+        {
+          message: 'tuture: Ignore this commit',
+          files: ['tuture.yml'],
+        },
+        {
+          message: 'Do some other thing',
+          files: ['index.html'],
+        },
+      ];
+      testInit(testRepo);
+    });
+
     describe('no commit at all', () => {
       const gitRepo = utils.createGitRepo([]);
       tmpDirs.push(gitRepo);
@@ -80,6 +98,10 @@ describe('tuture init', () => {
 
 function testInit(testRepo = utils.exampleRepo, ignoreTuture = false) {
   const gitRepo = utils.createGitRepo(testRepo, ignoreTuture);
+
+  // Remove commits with commit messages starting with `tuture:`
+  const expectedRepo = testRepo.filter(commit => !commit.message.startsWith('tuture:'));
+
   tmpDirs.push(gitRepo);
   process.chdir(gitRepo);
   const cp = utils.run(['init', '-y']);
@@ -96,14 +118,14 @@ function testInit(testRepo = utils.exampleRepo, ignoreTuture = false) {
   it('should create .tuture/diff directory', () => {
     const diffPath = path.join('.tuture', 'diff');
     expect(fs.existsSync(diffPath)).toBe(true);
-    expect(fs.readdirSync(diffPath).length).toBe(testRepo.length);
+    expect(fs.readdirSync(diffPath).length).toBe(expectedRepo.length);
   });
 
   it('should create correct tuture.yml with default values', () => {
     expect(fs.existsSync('tuture.yml')).toBe(true);
 
     const tuture = yaml.safeLoad(fs.readFileSync('tuture.yml'));
-    testTutureObject(testRepo, tuture);
+    testTutureObject(tuture, expectedRepo);
   });
 
   it('should have .gitignore properly configured', () => {
@@ -119,26 +141,28 @@ function testInit(testRepo = utils.exampleRepo, ignoreTuture = false) {
   });
 }
 
-function testTutureObject(testRepo, tuture) {
+function testTutureObject(tuture, expectedRepo) {
   // Expect metadata to be default values.
   expect(tuture.name).toBe('My Awesome Tutorial');
   expect(tuture.version).toBe('0.0.1');
   expect(tuture.language).toBe('en');
 
-  expect(tuture.steps.length).toBe(testRepo.length);
+  expect(tuture.steps.length).toBe(expectedRepo.length);
+
+  const steps = tuture.steps;
 
   // Check equivalence of each step.
-  for (let i = 0; i < testRepo.length; i++) {
-    expect(tuture.steps[i].name).toBe(testRepo[i].message);
-    expect(tuture.steps[i].explain).toBe(EXPLAIN_PLACEHOLDER);
-    expect(tuture.steps[i].diff.length).toBe(testRepo[i].files.length);
+  for (let i = 0; i < steps.length; i++) {
+    expect(steps[i].name).toBe(expectedRepo[i].message);
+    expect(steps[i].explain).toBe(EXPLAIN_PLACEHOLDER);
+    expect(steps[i].diff.length).toBe(expectedRepo[i].files.length);
 
-    for (let j = 0; j < testRepo[i].files.length; j++) {
-      expect(tuture.steps[i].diff[j].file).toBe(testRepo[i].files[j]);
-      expect(tuture.steps[i].diff[j].explain).toBe(EXPLAIN_PLACEHOLDER);
+    for (let j = 0; j < expectedRepo[i].files.length; j++) {
+      expect(steps[i].diff[j].file).toBe(expectedRepo[i].files[j]);
+      expect(steps[i].diff[j].explain).toBe(EXPLAIN_PLACEHOLDER);
 
-      if (shouldBeCollapsed(testRepo[i].files[j])) {
-        expect(tuture.steps[i].diff[j].collapse).toBe(true);
+      if (shouldBeCollapsed(expectedRepo[i].files[j])) {
+        expect(steps[i].diff[j].collapse).toBe(true);
       }
     }
   }


### PR DESCRIPTION
Sorry about doing multiple things in a single PR, sometimes temptations are so ...overwhelming you know.

## Error handling refactoring

`signale.error(...); process.exit(1);` is such a common pattern that I've decided to refactor this into a dedicated function `errAndExit`.

## Suppress Git output

Before:

```
$ tuture init
fatal: Not a git repository (or any of the parent directories): .git

✖  fatal     Not a git repository (or any of the parent directories): .git

```

After:

```
$ tuture init
✖  fatal     Not a git repository (or any of the parent directories): .git
```

## Fix bug of ignoring certain commits

Previously tuture-related commits (starting with `tuture:`) are not correctly ignored. Now the bug is fixed and I've added a test case to cover this situation.