### PR TITLE
cli: Add diff parsing

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const git = require('simple-git/promise')('.').silent(true);
+const parser = require('gitdiff-parser');
 const path = require('path');
 
 const common = require('./common');
@@ -40,6 +41,19 @@ async function getGitLogs() {
   return output.trim().split('\n');
 }
 
+function parseDiff(diff) {
+  const files = parser.parse(diff);
+
+  return files.map((file) => {
+    const hunks = file.hunks.map(hunk => ({
+      ...hunk,
+      isPlain: false,
+    }));
+
+    return { ...file, hunks };
+  });
+}
+
 /**
  * Get diff of a given commit.
  * @param {String} commit Commit ID
@@ -63,13 +77,22 @@ async function getGitDiff(commit) {
 
 /**
  * Store diff of a given commit to a file.
- * @param {String} commit Commit ID
+ * @param {string[]} commits Array of commit hashes
  */
-async function storeDiff(commit) {
-  const output = await runGitCommand(['show', commit]);
-  const diff = output.split('\n\n').slice(-1)[0];
-  const diffPath = path.join(common.TUTURE_ROOT, 'diff', `${commit}.diff`);
-  fs.writeFileSync(diffPath, diff);
+async function storeDiff(commits) {
+  const diffPromises = commits.map(async (commit) => {
+    const output = await runGitCommand(['show', commit]);
+    const diffText = output.split('\n\n').slice(-1)[0];
+    const diff = parseDiff(diffText);
+    return { commit, diff };
+  });
+
+  Promise.all(diffPromises).then((diffs) => {
+    fs.writeFileSync(
+      path.join(common.TUTURE_ROOT, 'diff.json'),
+      JSON.stringify(diffs),
+    );
+  });
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,19 +67,23 @@ async function promptMetaData(shouldPrompt) {
 }
 
 async function makeSteps() {
-  const logs = await git.getGitLogs();
-  return logs
+  let logs = await git.getGitLogs();
+  logs = logs
     .reverse()
     // filter out commits whose commit message starts with 'tuture:'
-    .filter(log => !log.slice(8, log.length).startsWith('tuture:'))
-    .map(async (log) => {
-      const commit = log.slice(0, 7);
+    .filter(log => !log.slice(8, log.length).startsWith('tuture:'));
+
+  // Store all diff into .tuture/diff.json
+  const commits = logs.map(log => log.slice(0, 7));
+  await git.storeDiff(commits);
+
+  return logs
+    .map(async (log, idx) => {
       const msg = log.slice(8, log.length);
-      await git.storeDiff(commit);
       return {
         name: msg,
-        commit,
-        diff: await git.getGitDiff(commit),
+        commit: commits[idx],
+        diff: await git.getGitDiff(commits[idx]),
       };
     });
 }
@@ -122,11 +126,15 @@ async function initTuture(options) {
   await git.checkGitEnv();
 
   const tuture = await promptMetaData(!options.yes);
-  fs.mkdirpSync(path.join(common.TUTURE_ROOT, 'diff'));
+  fs.mkdirSync(common.TUTURE_ROOT);
 
   try {
     tuture.steps = await getSteps();
 
+    fs.writeFileSync(
+      path.join(common.TUTURE_ROOT, 'tuture.json'),
+      JSON.stringify(tuture),
+    );
     fs.writeFileSync('tuture.yml', yaml.safeDump(tuture));
     signale.success('tuture.yml is created!');
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -104,6 +104,18 @@ async function getSteps() {
 }
 
 /**
+ * Write tuture object into tuture.yml and .tuture/tuture.json
+ * @param {Object} tuture Tuture object
+ */
+function writeTuture(tuture) {
+  fs.writeFileSync(
+    path.join(common.TUTURE_ROOT, 'tuture.json'),
+    JSON.stringify(tuture),
+  );
+  fs.writeFileSync('tuture.yml', yaml.safeDump(tuture));
+}
+
+/**
  * Append .tuture rule to gitignore.
  * If it's already ignored, do nothing.
  * If .gitignore doesn't exist, create one and add the rule.
@@ -131,11 +143,7 @@ async function initTuture(options) {
   try {
     tuture.steps = await getSteps();
 
-    fs.writeFileSync(
-      path.join(common.TUTURE_ROOT, 'tuture.json'),
-      JSON.stringify(tuture),
-    );
-    fs.writeFileSync('tuture.yml', yaml.safeDump(tuture));
+    writeTuture(tuture);
     signale.success('tuture.yml is created!');
 
     appendGitignore();
@@ -171,8 +179,8 @@ async function reloadTuture() {
   });
 
   tuture.steps = currentSteps;
-  fs.writeFileSync('tuture.yml', yaml.safeDump(tuture));
-  signale.success('tuture.yml is reloaded!');
+  writeTuture(tuture);
+  signale.success('Reload complete!');
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "commander": "^2.15.1",
     "fs-extra": "^6.0.1",
+    "gitdiff-parser": "^0.0.8",
     "js-yaml": "^3.11.0",
     "minimatch": "^3.0.4",
     "ora": "^2.1.0",

--- a/tests/destroy.test.js
+++ b/tests/destroy.test.js
@@ -23,7 +23,7 @@ describe('tuture destroy', () => {
     });
 
     it('should delete all tuture files', () => {
-      expect(fs.existsSync(path.join(repoPath, '.tuture', 'diff'))).toBe(false);
+      expect(fs.existsSync(path.join(repoPath, '.tuture'))).toBe(false);
       expect(fs.existsSync(path.join(repoPath, 'tuture.yml'))).toBe(false);
     });
 

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -107,17 +107,24 @@ function testInit(testRepo = utils.exampleRepo, ignoreTuture = false) {
     expect(cp.status).toBe(0);
   });
 
-  it('should create .tuture/diff directory', () => {
-    const diffPath = path.join(repoPath, '.tuture', 'diff');
-    expect(fs.existsSync(diffPath)).toBe(true);
-    expect(fs.readdirSync(diffPath).length).toBe(expectedRepo.length);
+  it('should create valid diff.json', () => {
+    const diffContent = utils.parseInternalFile(repoPath, 'diff.json');
+    expect(diffContent).toHaveLength(expectedRepo.length);
+    expect(diffContent[0]).toHaveProperty('commit');
+    expect(diffContent[0]).toHaveProperty('diff');
   });
 
-  it('should create correct tuture.yml with default values', () => {
+  it('should create correct tuture.[yml|json] with default values', () => {
     const tutureYmlPath = path.join(repoPath, 'tuture.yml');
+    const tutureJsonPath = path.join(repoPath, '.tuture', 'tuture.json');
     expect(fs.existsSync(tutureYmlPath)).toBe(true);
+    expect(fs.existsSync(tutureJsonPath)).toBe(true);
 
+    // Test if tuture.yml and tuture.json are strictly equivalent.
     const tuture = yaml.safeLoad(fs.readFileSync(tutureYmlPath));
+    const tuture2 = utils.parseInternalFile(repoPath, 'tuture.json');
+    expect(tuture).toStrictEqual(tuture2);
+
     testTutureObject(tuture, expectedRepo);
   });
 
@@ -128,7 +135,7 @@ function testInit(testRepo = utils.exampleRepo, ignoreTuture = false) {
     const ignoreRules = fs.readFileSync(gitignorePath).toString();
 
     // .tuture is ignored.
-    expect(ignoreRules.indexOf('.tuture')).not.toBe(-1);
+    expect(ignoreRules).toContain('.tuture');
 
     // .tuture is ignored only once.
     expect(ignoreRules.indexOf('.tuture')).toBe(ignoreRules.lastIndexOf('.tuture'));
@@ -141,14 +148,14 @@ function testTutureObject(tuture, expectedRepo) {
   expect(tuture.version).toBe('0.0.1');
   expect(tuture.language).toBe('en');
 
-  expect(tuture.steps.length).toBe(expectedRepo.length);
+  expect(tuture.steps).toHaveLength(expectedRepo.length);
 
   const steps = tuture.steps;
 
   // Check equivalence of each step.
   for (let i = 0; i < steps.length; i++) {
     expect(steps[i].name).toBe(expectedRepo[i].message);
-    expect(steps[i].diff.length).toBe(expectedRepo[i].files.length);
+    expect(steps[i].diff).toHaveLength(expectedRepo[i].files.length);
 
     for (let j = 0; j < expectedRepo[i].files.length; j++) {
       expect(steps[i].diff[j].file).toBe(expectedRepo[i].files[j]);

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -70,8 +70,20 @@ function createGitRepo(repo = exampleRepo, ignoreTuture = false) {
   return repoPath;
 }
 
+/**
+ * Parse internal json files.
+ * @param {string} repoPath Path to the repository
+ * @param {string} fileName Filename of the internal JSON file
+ */
+function parseInternalFile(repoPath, fileName) {
+  return JSON.parse(
+    fs.readFileSync(path.join(repoPath, '.tuture', fileName))
+  );
+}
+
 exports.exampleRepo = exampleRepo;
 exports.tutureRunnerFactory = tutureRunnerFactory;
 exports.gitRunnerFactory = gitRunnerFactory;
 exports.createEmptyDir = createEmptyDir;
 exports.createGitRepo = createGitRepo;
+exports.parseInternalFile = parseInternalFile;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,6 +1347,10 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gitdiff-parser@^0.0.8:
+  version "0.0.8"
+  resolved "http://registry.npm.taobao.org/gitdiff-parser/download/gitdiff-parser-0.0.8.tgz#d1634950ffe09aec2909ae83fe1e72f5613ab8b9"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "http://registry.npm.taobao.org/glob-base/download/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"


### PR DESCRIPTION
Now `init` and `reload` commands will take care of following internal files:

- **.tuture/tuture.json**, which is JSON translation of **tuture.yml**

- **.tuture/diff.json**, which is an array of diff objects like this:

```json
[
  {
    "commit": "3c0ffa1",
    "diff": [
      {
        "oldPath": "commit1.js",
        "newPath": "commit1.js",
        "hunks": [],
        "oldRevision": "0000000",
        "newRevision": "e69de29",
        "type": "new"
      }
    ]
  },
  {
    "commit": "f60215e",
    "diff": [
      {
        "oldPath": "commit2.js",
        "newPath": "commit2.js",
        "hunks": [],
        "oldRevision": "0000000",
        "newRevision": "e69de29",
        "type": "new"
      }
    ]
  }
]
```

Note that the `diff` property is actually the return value of [`parseDiff`](https://github.com/tutureproject/renderer/blob/master/src/utils/parseDiff.ts) funtion.