### PR TITLE
Enable init in non-Git dir or in a repo with no commit

### DIFF
--- a/docs/CLI_COMMANDS.md
+++ b/docs/CLI_COMMANDS.md
@@ -6,7 +6,13 @@ Following commands assume that you are working on a Git repo. If you does not ha
 
 Initialize a Tuture tutorial.
 
-Tuture will prompt you to answer following questions (if `-y` or `--yes` option is not given):
+This command will go through following procedures:
+
+1. Check if Git is installed on your machine. If not, Tuture will stop and output error message.
+
+2. Check if current working directory is a Git repo. If you are not in a Git repo and `-y` option is not given, Tuture will ask for confirmation on whether you would like to initialize one. If your answer is no, Tuture will abort this command. Otherwise, Tuture will run `git init` in cwd and move on.
+
+3. Prompt you to answer following questions (if `-y` or `--yes` option is not given):
 
 | Prompt             | Fields     | Required/Optional | Default            | Meaning                                                      |
 | ------------------ | ---------- | ----------------- | ------------------ | ------------------------------------------------------------ |
@@ -16,11 +22,9 @@ Tuture will prompt you to answer following questions (if `-y` or `--yes` option 
 | Topics? | `topics` | Optional  | javascript,  git, cli | Topics of this tutorial, separated with spaces or commas, such as `express, mongodb` |
 | Maintainer email? | `email` | Optional | me@example.com | Maintainer email of this tutorial |
 
-Afterwards Tuture will do three things for you:
+4. Create **tuture.yml** which is everything you need to write your tutorial (refer to [tuture.yml Specification](TUTURE_YML_SPEC.md) for detailed information), and **.tuture** directory which houses diff data of each commit.
 
-1. Create **tuture.yml** which is everything you need to write your tutorial (refer to [tuture.yml Specification](TUTURE_YML_SPEC.md) for detailed information), and **.tuture** directory which houses diff data of each commit.
-
-2. Append following rule to your `.gitignore` (Tuture will create one if not exists):
+5. Append following rule to your `.gitignore` (Tuture will create one if not exists):
 
 ```
 # Tuture supporting files
@@ -28,11 +32,7 @@ Afterwards Tuture will do three things for you:
 .tuture
 ```
 
-3. Add Git post-commit hook for calling `tuture reload` after each commit (create one if not exists).
-
-### Preconditions
-
-Current working directory should be a Git repo with at least one commit.
+6. Add Git post-commit hook for calling `tuture reload` after each commit (create one if not exists).
 
 ### Options
 

--- a/docs/CLI_COMMANDS.zh-CN.md
+++ b/docs/CLI_COMMANDS.zh-CN.md
@@ -6,7 +6,13 @@
 
 初始化一个 Tuture 教程。
 
-Tuture 会询问你以下问题（如果使用了 `-y` 或 `--yes` 则不会询问）：
+此命令会执行以下步骤：
+
+1. 检查 Git 是否在本机安装。如果没有安装，Tuture 会停止运行并显示出错信息。
+
+2. 检查当前所在目录是否为 Git 仓库。如果不是 Git 仓库并且没有提供 `-y` 选项，Tuture 就会询问是否确认要将当前目录初始化为 Git 仓库。如果你回答了否，Tuture 会终止运行。否则 Tuture 会执行 `git init` 命令并继续执行。
+
+3. 询问你以下问题（如果使用了 `-y` 或 `--yes` 则不会询问）：
 
 | 询问               | 对应字段   | 必要/可选 | 默认值             | 含义                                                         |
 | ------------------ | ---------- | --------- | ------------------ | ------------------------------------------------------------ |
@@ -16,18 +22,16 @@ Tuture 会询问你以下问题（如果使用了 `-y` 或 `--yes` 则不会询�
 | Topics?            | `topics`   | 可选      | -                  | 此教程的主题，不同的主题用空格或逗号分隔，例如 `express,mongodb` |
 | Maintainer email?  | `email`    | 可选      | -                  | 此教程维护者的电子邮件                                       |
 
-然后 Tuture 会做以下三件事：
+4. 创建写教程所需的 **tuture.yml** 文件（详细说明请参考 [tuture.yml 规格说明](TUTURE_YML_SPEC.zh-CN.md)）和用于存放 Tuture 所需的 diff 数据 **.tuture** 目录，。
 
-1. 创建写教程所需的 **tuture.yml** 文件（详细说明请参考 [tuture.yml 规格说明](TUTURE_YML_SPEC.zh-CN.md)）和用于存放 Tuture 所需的 diff 数据 **.tuture** 目录，。
-
-2. 在你的 `.gitignore` 中添加以下规则（如果没有会为你创建）：
+5. 在你的 `.gitignore` 中添加以下规则（如果没有会为你创建）：
 
 ```
 # Tuture supporting files
 .tuture
 ```
 
-3. 增加 Git post-commit 钩子（如果没有会为你创建），用于每次提交后触发 `tuture reload`。
+6. 增加 Git post-commit 钩子（如果没有会为你创建），用于每次提交后触发 `tuture reload`。
 
 ### 前提条件
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -2,17 +2,16 @@ const fs = require('fs-extra');
 const git = require('simple-git/promise')('.').silent(true);
 const parser = require('gitdiff-parser');
 const path = require('path');
+const which = require('which');
 
 const common = require('./common');
 
 /**
- * Check cwd is a valid Git repo with at least one commit.
+ * Check if Git command is available.
  */
-async function checkGitEnv() {
-  try {
-    await git.log();
-  } catch (err) {
-    common.errAndExit(err.message);
+function checkGitExecutable() {
+  if (which.sync('git', { nothrow: true }) === null) {
+    common.errAndExit('Git is not installed on your machine!');
   }
 }
 
@@ -23,13 +22,15 @@ async function checkGitEnv() {
  * @returns {String} stdout of running this git command
  */
 async function runGitCommand(args) {
-  let res = null;
-  try {
-    res = await git.raw(args);
-  } catch (err) {
-    common.errAndExit(err.message);
-  }
+  const res = await git.raw(args);
   return res;
+}
+
+/**
+ * Initialize a Git repo.
+ */
+async function initGit() {
+  await runGitCommand(['init']);
 }
 
 /**
@@ -37,8 +38,13 @@ async function runGitCommand(args) {
  * @returns {Array} Git commit messages
  */
 async function getGitLogs() {
-  const output = await runGitCommand(['log', '--oneline', '--no-merges']);
-  return output.trim().split('\n');
+  try {
+    const output = await runGitCommand(['log', '--oneline', '--no-merges']);
+    return output.trim().split('\n');
+  } catch (err) {
+    // Current repo doesn't have any commit yet.
+    return [];
+  }
 }
 
 function parseDiff(diff) {
@@ -138,7 +144,8 @@ function removeGitHook() {
   }
 }
 
-exports.checkGitEnv = checkGitEnv;
+exports.checkGitExecutable = checkGitExecutable;
+exports.initGit = initGit;
 exports.getGitLogs = getGitLogs;
 exports.getGitDiff = getGitDiff;
 exports.storeDiff = storeDiff;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,7 +135,25 @@ function appendGitignore() {
  * @param {Object} options Command-line options
  */
 async function initTuture(options) {
-  await git.checkGitEnv();
+  git.checkGitExecutable();
+
+  if (!fs.existsSync('.git')) {
+    const onCancel = () => common.errAndExit('Aborted!');
+
+    const response = options.yes ? { answer: true } : await prompts({
+      type: 'confirm',
+      name: 'answer',
+      message: 'You are not in a Git repository, do you want to initialize one?',
+      initial: false,
+    }, { onCancel });
+
+    if (!response.answer) {
+      common.errAndExit('Aborted!');
+    } else {
+      await git.initGit();
+      signale.success('Git repo is initialized!');
+    }
+  }
 
   const tuture = await promptMetaData(!options.yes);
   fs.mkdirSync(common.TUTURE_ROOT);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "ora": "^2.1.0",
     "prompts": "^0.1.8",
     "signale": "^1.1.0",
-    "simple-git": "^1.95.1"
+    "simple-git": "^1.95.1",
+    "which": "^1.3.1"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -8,7 +8,7 @@ const { shouldBeCollapsed } = require('../lib/common');
 // Tmp directories used in tests.
 let tmpDirs = Array();
 
-describe('tuture init', () => {
+describe('tuture init -y', () => {
 
   afterAll(() => tmpDirs.forEach(dir => fs.removeSync(dir)));
 
@@ -17,9 +17,16 @@ describe('tuture init', () => {
     const tutureRunner = utils.tutureRunnerFactory(nonRepoPath);
     tmpDirs.push(nonRepoPath);
 
-    it('should refuse to init', () => {
-      const cp = tutureRunner(['init', '-y']);
-      expect(cp.status).toBe(1);
+    const cp = tutureRunner(['init', '-y']);
+
+    it('should exit with status 0', () => {
+      expect(cp.status).toBe(0);
+    });
+
+    it('should have all needed files created', () => {
+      expect(fs.existsSync(path.join(nonRepoPath, 'tuture.yml'))).toBe(true);
+      expect(fs.existsSync(path.join(nonRepoPath, '.tuture', 'tuture.json'))).toBe(true);
+      expect(fs.existsSync(path.join(nonRepoPath, '.tuture', 'diff.json'))).toBe(true);
     });
   });
 
@@ -78,17 +85,6 @@ describe('tuture init', () => {
         },
       ];
       testInit(testRepo);
-    });
-
-    describe('no commit at all', () => {
-      const repoPath = utils.createGitRepo([]);
-      const tutureRunner = utils.tutureRunnerFactory(repoPath);
-      tmpDirs.push(repoPath);
-
-      it('should refuse to init', () => {
-        const cp = tutureRunner(['init', '-y']);
-        expect(cp.status).toBe(1);
-      });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3722,7 +3722,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "http://registry.npm.taobao.org/which-module/download/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.12, which@^1.2.9, which@^1.3.0:
+which@^1.2.12, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "http://registry.npm.taobao.org/which/download/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:


### PR DESCRIPTION
Closes #70.

Now when you run `tuture init` outside a Git repo, Tuture will prompt you:

![image](https://user-images.githubusercontent.com/23410977/42409126-44a52144-8208-11e8-9c2d-52d978ea9122.png)

If your answer is yes, Tuture will `git init` and generate **tuture.yml** like this:

```yaml
name: My Awesome Tutorial
version: 0.0.1
language: en
steps: []
```

Of course if your specify `-y` option, Tuture will do everything without asking for confirmation.