### PR TITLE
cli: Fix destroy prompting bug

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -227,13 +227,13 @@ async function destroyTuture(options) {
 
   const onCancel = () => common.errAndExit('Aborted!');
 
-  const answer = options.force ? true : await prompts({
+  const response = options.force ? { answer: true } : await prompts({
     type: 'confirm',
     name: 'answer',
     message: 'Are you sure?',
     initial: false,
   }, { onCancel });
-  if (!answer) {
+  if (!response.answer) {
     common.errAndExit('Aborted!');
   }
 


### PR DESCRIPTION
Previously, when you run `tuture destroy` and answer **no** to the question, Tuture would still destroy the tutorial, because `answer` is always `true` (it's a non-empty object).