### PR TITLE
cli: Make init command idempotent

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,6 +135,11 @@ function appendGitignore() {
  * @param {Object} options Command-line options
  */
 async function initTuture(options) {
+  if (common.ifTutureSuiteExists()) {
+    signale.success('Tuture has already been initialized!');
+    process.exit(0);
+  }
+
   git.checkGitExecutable();
 
   if (!fs.existsSync('.git')) {


### PR DESCRIPTION
Closes #85.

Now running init command for multiple times will have the same effect as running once., as [idempotence](https://en.wikipedia.org/wiki/Idempotent) is crucial for CLI tools.