### PR TITLE
feat: Generate diff before up command

### DIFF
--- a/docs/CLI_COMMANDS.md
+++ b/docs/CLI_COMMANDS.md
@@ -69,15 +69,16 @@ Output usage information.
 
 Render your tutorial in the browser.
 
-This command will invoke `tuture-renderer` under the hood, which should have been installed before `tuture`. If `tuture-renderer` is not available on your machine somehow, you can manually install it with **npm**:
+Whether you have initialized with `tuture init` or have just cloned a Tuture tutorial repository, running `tuture up` both suffices.
 
-```bash
-$ npm i -g tuture-renderer
-```
+> This command will invoke `tuture-renderer` under the hood, which should have been installed before `tuture`. If `tuture-renderer` is not available on your machine somehow, you can manually install it with **npm**:
+> ```bash
+> $ npm i -g tuture-renderer
+> ```
 
 ### Preconditions
 
-Current working directory should already be initialized with `tuture init`.
+Current working directory should already be a Git repository with **tuture.yml** present.
 
 ### Options
 

--- a/docs/CLI_COMMANDS.zh-CN.md
+++ b/docs/CLI_COMMANDS.zh-CN.md
@@ -72,15 +72,16 @@ Tuture 通过从 Git 日志中提取最新的变化来实现以下两件事：
 
 在浏览器中渲染教程。
 
-这条命令内部会调用 `tuture-renderer` 命令，这个命令程序应当在安装 `tuture` 之前就已经安装完成了。如果你的机器上不知为何不能使用 `tuture-renderer`，你可以用 **npm** 手动安装;
+不管你已经用 `tuture init` 命令初始化过，还是刚 clone 了一个 Tuture 教程仓库，运行 `tuture up` 都已足够。
 
-```bash
-$ npm i -g tuture-renderer
-```
+> 这条命令内部会调用 `tuture-renderer` 命令，这个命令程序应当在安装 `tuture` 之前就已经安装完成了。如果你的机器上不知为何不能使用 `tuture-renderer`，你可以用 **npm** 手动安装;
+> ```bash
+> $ npm i -g tuture-renderer
+> ```
 
 ### 前提条件
 
-当前工作目录应当已经用 `tuture init` 命令初始化完成。
+当前工作目录应当是包含 **tuture.yml** 文件的 Git 仓库。
 
 ### 选项
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,11 +13,8 @@ const yaml = require('js-yaml');
 const { tutureRoot } = require('./config');
 const git = require('./git');
 
-/**
- * Check if .tuture directory and tuture.yml both exists.
- */
-function ifTutureSuiteExists() {
-  return fs.existsSync(tutureRoot) && fs.existsSync('tuture.yml');
+function ifTutureYmlExists() {
+  return fs.existsSync('tuture.yml');
 }
 
 /**
@@ -147,7 +144,7 @@ function appendGitignore() {
  * @param {Object} options Command-line options
  */
 async function initTuture(options) {
-  if (ifTutureSuiteExists()) {
+  if (ifTutureYmlExists()) {
     signale.success('Tuture has already been initialized!');
     process.exit(0);
   }
@@ -195,7 +192,7 @@ async function initTuture(options) {
  * Update Tuture files (diff files and tuture.yml).
  */
 async function reloadTuture() {
-  if (!ifTutureSuiteExists()) {
+  if (!ifTutureYmlExists()) {
     errAndExit('Tuture has not been initialized!');
   }
 
@@ -227,9 +224,14 @@ async function reloadTuture() {
 /**
  * Start up tuture-renderer.
  */
-function startRenderer() {
-  if (!ifTutureSuiteExists()) {
-    errAndExit('Tuture has not been initialized!');
+async function startRenderer() {
+  if (!ifTutureYmlExists()) {
+    errAndExit('tuture.yml not found!');
+  }
+
+  if (!fs.existsSync(tutureRoot)) {
+    fs.mkdirSync(tutureRoot);
+    await reloadTuture();
   }
 
   try {
@@ -245,7 +247,7 @@ function startRenderer() {
  * @param {Object} options Command-line options
  */
 async function destroyTuture(options) {
-  if (!ifTutureSuiteExists()) {
+  if (!ifTutureYmlExists()) {
     errAndExit('No Tuture tutorial to destroy!');
   }
 

--- a/tests/init.test.js
+++ b/tests/init.test.js
@@ -77,7 +77,7 @@ describe('tuture init -y', () => {
         },
         {
           message: 'tuture: Ignore this commit',
-          files: ['tuture.yml'],
+          files: ['foobar.js'],
         },
         {
           message: 'Do some other thing',


### PR DESCRIPTION
Cover a new use case for sharing tutorials: clone other people's repositories and run `tuture up` to read the tutorial. In order to cover this use case, below are some new behaviors:

- Before running `tuture up`, if there is **tuture.yml** present but no **.tuture** directory, Tuture will run `reload` command to generate the diff needed by renderers
- When running `tuture init` and there is **tuture.yml** present, Tuture will refuse to initialize (and the valid command will be `reload` or `up`)