### PR TITLE
Check yaml syntax

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,6 +35,21 @@ function errAndExit(message) {
 }
 
 /**
+ * Load tuture object from tuture.yml.
+ * If there is syntax error, log it and exit with status 1.
+ * @returns {Object} The tuture object.
+ */
+function loadTuture() {
+  let tuture = null;
+  try {
+    tuture = yaml.safeLoad(fs.readFileSync('tuture.yml'), 'utf8');
+  } catch (err) {
+    errAndExit(`tuture.yml syntax error\n\n${err.message}`);
+  }
+  return tuture;
+}
+
+/**
  * Construct metadata object from user prompt
  * @param {boolean} shouldPrompt Whether `-y` option is provided
  * @returns {object} Metadata object to be dumped into tuture.yml
@@ -200,12 +215,7 @@ async function reloadTuture() {
     errAndExit('Git is not installed on your machine!');
   }
 
-  let tuture = null;
-  try {
-    tuture = yaml.safeLoad(fs.readFileSync('tuture.yml'), 'utf8');
-  } catch (err) {
-    errAndExit(err.message);
-  }
+  const tuture = loadTuture();
 
   const currentSteps = await getSteps();
   currentSteps.forEach((currentStep, index) => {
@@ -233,6 +243,9 @@ async function startRenderer() {
     fs.mkdirSync(tutureRoot);
     await reloadTuture();
   }
+
+  // Check for tuture.yml syntax.
+  loadTuture();
 
   try {
     signale.success('Tuture renderer is served on http://localhost:3000.');

--- a/tests/up.test.js
+++ b/tests/up.test.js
@@ -1,4 +1,6 @@
 const fs = require('fs-extra');
+const path = require('path');
+
 const utils = require('./utils');
 
 // Tmp directories used in tests.
@@ -18,4 +20,20 @@ describe('tuture up', () => {
       expect(cp.status).toBe(1);
     });
   });
+
+  describe('tuture.yml syntax error', () => {
+    const repoPath = utils.createGitRepo();
+    const tutureRunner = utils.tutureRunnerFactory(repoPath);
+    tmpDirs.push(repoPath);
+    tutureRunner(['init', '-y']);
+
+    const flawedTuture = 'foo: bar:';
+    fs.writeFileSync(path.join(repoPath, 'tuture.yml'), flawedTuture);
+
+    it('should report syntax error', () => {
+      const cp = tutureRunner(['up']);
+      expect(cp.status).toBe(1);
+      expect(cp.stdout.toString()).toMatch(/syntax error/);
+    });
+  })
 });


### PR DESCRIPTION
Now when you have syntax error in **tuture.yml**, Tuture will tell you:

```
$ tuture up
✖  fatal     tuture.yml syntax error

bad indentation of a sequence entry at line 24, column 25:
          - file: index.html:
                            ^
```