### PR TITLE
Fix firing renderer before reload complete

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -104,12 +104,12 @@ async function storeDiff(commits) {
     return { commit, diff };
   });
 
-  Promise.all(diffPromises).then((diffs) => {
-    fs.writeFileSync(
-      path.join(tutureRoot, 'diff.json'),
-      JSON.stringify(diffs),
-    );
-  });
+  const diffs = await Promise.all(diffPromises);
+
+  fs.writeFileSync(
+    path.join(tutureRoot, 'diff.json'),
+    JSON.stringify(diffs),
+  );
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@
 
 const cp = require('child_process');
 const fs = require('fs-extra');
+const path = require('path');
 
 const ora = require('ora');
 const prompts = require('prompts');
@@ -239,8 +240,10 @@ async function startRenderer() {
     errAndExit('tuture.yml not found!');
   }
 
-  if (!fs.existsSync(tutureRoot)) {
-    fs.mkdirSync(tutureRoot);
+  if (!fs.existsSync(path.join(tutureRoot, 'diff.json'))) {
+    if (!fs.existsSync(tutureRoot)) {
+      fs.mkdirSync(tutureRoot);
+    }
     await reloadTuture();
   }
 


### PR DESCRIPTION
Now Tuture will make sure `diff.json` is reloaded before running `tuture up`.