### PR TITLE
Drop support for Node 6 and 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: node_js
 sudo: false
 
 node_js:
-  - "6"
-  - "7"
   - "8"
   - "9"
   - "10"


### PR DESCRIPTION
Node 6 & 7 is no longer officially supported, so remove their builds.