### PR TITLE
Update build system

### DIFF
--- a/commands/build.ts
+++ b/commands/build.ts
@@ -279,7 +279,9 @@ export default class Build extends BaseCommand {
         : path.join(path.dirname(dest), assetsPath || assetsRoot);
 
       // Copy all assets.
-      fs.copySync(assetsRoot, assetsDir, { overwrite: true });
+      if (fs.existsSync(assetsRoot)) {
+        fs.copySync(assetsRoot, assetsDir, { overwrite: true });
+      }
 
       // Replace asset paths if needed.
       const newTutorial = hexo

--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,6 @@
 export default {
   // Path to assets directory.
-  assetsPath: 'tuture-assets',
+  assetsRoot: 'tuture-assets',
 
   // Path to build outputs.
   buildPath: 'tuture-build',

--- a/constants.ts
+++ b/constants.ts
@@ -14,6 +14,4 @@ export const EDITOR_PATH = path.join(__dirname, 'editor');
 
 export const EDITOR_STATIC_PATH = path.join(EDITOR_PATH, 'static');
 
-export const GITHUB_RAW_PATH = 'https://raw.githubusercontent.com';
-
 export const TUTURE_COMMIT_PREFIX = 'tuture:';

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   "scripts": {
     "lint": "tslint -p . -t verbose",
     "test": "rimraf build && tsc && jest",
-    "build": "rimraf build && tsc && cp -r editor/build build/editor",
+    "build:editor": "cd editor && npm install && npm run build",
+    "build:cli": "rimraf build && tsc && cp -r editor/build build/editor",
+    "build": "npm run build:editor && npm run build:cli",
     "pkg": "./scripts/pack.sh",
     "prepack": "npm run build"
   },

--- a/server.ts
+++ b/server.ts
@@ -21,7 +21,7 @@ const diffPath = path.join(workspace, DIFF_PATH);
 const makeServer = (config: any) => {
   const app = express();
   const server = http.createServer(app);
-  const { assetsPath } = config;
+  const { assetsRoot } = config;
 
   // Socket.IO server instance.
   const io = socketio(server);
@@ -30,7 +30,7 @@ const makeServer = (config: any) => {
   const upload = multer({
     storage: multer.diskStorage({
       destination(req, file, cb) {
-        cb(null, assetsPath);
+        cb(null, assetsRoot);
       },
     }),
   });
@@ -42,7 +42,7 @@ const makeServer = (config: any) => {
   app.use(express.json());
   app.use(express.urlencoded({ extended: false }));
   app.use('/static', express.static(EDITOR_STATIC_PATH));
-  app.use(`/${assetsPath}`, express.static(assetsPath));
+  app.use(`/${assetsRoot}`, express.static(assetsRoot));
 
   app.get('/', (_, res) => {
     const html = fs
@@ -72,11 +72,11 @@ const makeServer = (config: any) => {
   });
 
   app.post('/upload', upload.single('file'), (req, res) => {
-    if (!fs.existsSync(assetsPath)) {
-      fs.mkdirSync(assetsPath);
+    if (!fs.existsSync(assetsRoot)) {
+      fs.mkdirSync(assetsRoot);
     }
 
-    const savePath = path.join(assetsPath, req.file.filename);
+    const savePath = path.join(assetsRoot, req.file.filename);
     res.json({ path: savePath });
   });
 


### PR DESCRIPTION
Collect all assets and replace their paths in markdown correctly.

Feel free to test the following cases:

- `tuture build`. This is the default mode.
- `tuture build -o mytutorial.md`. This should output the markdown with given path and name.
- `tuture build --assetsPath assets`. This should create a customized assets directory and replace all asset paths in markdown.
- `tuture build --hexo`. This should output tutorials ready for hexo blogs.